### PR TITLE
Added Samsung Note 5 (Android 6.0.1)'s case

### DIFF
--- a/src/__test__/index.test.js
+++ b/src/__test__/index.test.js
@@ -36,6 +36,12 @@ const MOBILE = {
     CHROME: [],
   },
   SAMSUNG: {
+    MESSENGER: ['Mozilla/5.0 (Linux; Android 6.0.1; SM-N9208 Build/MMB29K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36 [FB_IAB/MESSENGER;FBAV/118.0.0.19.82;]'],
+    FACEBOOK: ['Mozilla/5.0 (Linux; Android 6.0.1; SM-N9208 Build/MMB29K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/125.0.0.16.80;]'],
+    LINE: ['Mozilla/5.0 (Linux; Android 6.0.1; SM-N9208 Build/MMB29K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36 Line/7.4.0/IAB'],
+    WECHAT: ['Mozilla/5.0 (Linux; Android 6.0.1; SM-N9208 Build/MMB29K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36 MicroMessenger/6.5.7.1041 NetType/WIFI Language/zh_TW'],
+    INSTAGRAM: ['Mozilla/5.0 (Linux; Android 6.0.1; SM-N9208 Build/MMB29K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36 Instagram 10.22.0 Android (23/6.0.1; 560dpi; 1440x2560; samsung; SM-N9208; noblelte; samsungexynos7420; zh_TW)'],
+    CHROME: ['Mozilla/5.0 (Linux; Android 6.0.1; SM-N9208 Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36'],
   },
   WINDOWS: {
     FACEBOOK: [],

--- a/src/__test__/index.test.js
+++ b/src/__test__/index.test.js
@@ -35,7 +35,7 @@ const MOBILE = {
     WECHAT: [],
     CHROME: [],
   },
-  SAMSUND: {
+  SAMSUNG: {
   },
   WINDOWS: {
     FACEBOOK: [],

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const IS_MOBILE = [
 ];
 
 const BROWSER = {
-  messenger: [/\bFB\w\w\/Messenger/],
+  messenger: [/\bFB\w+\/Messenger/i],
   facebook: [/\bFB\w\w\//],
   line: [/\bLine\//i],
   wechat: [/\bMicroMessenger\//i],


### PR DESCRIPTION
* I added the user-agent strings of several apps on my Samsung Note 5:
	* Messenger: `Mozilla/5.0 (Linux; Android 6.0.1; SM-N9208 Build/MMB29K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36 [FB_IAB/MESSENGER;FBAV/118.0.0.19.82;]`
	* Facebook: `Mozilla/5.0 (Linux; Android 6.0.1; SM-N9208 Build/MMB29K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/125.0.0.16.80;]`
	* LINE: `Mozilla/5.0 (Linux; Android 6.0.1; SM-N9208 Build/MMB29K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36 Line/7.4.0/IAB`
	* WeChat: `Mozilla/5.0 (Linux; Android 6.0.1; SM-N9208 Build/MMB29K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36 MicroMessenger/6.5.7.1041 NetType/WIFI Language/zh_TW`
	* Instagram: `Mozilla/5.0 (Linux; Android 6.0.1; SM-N9208 Build/MMB29K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36 Instagram 10.22.0 Android (23/6.0.1; 560dpi; 1440x2560; samsung; SM-N9208; noblelte; samsungexynos7420; zh_TW)`
	* Chrome: `Mozilla/5.0 (Linux; Android 6.0.1; SM-N9208 Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36`

	Detected by http://detectmobilebrowsers.com/mobile

* Fixed the detection of Facebook Messenger's regexp pattern, because it failed on Samsung's case.

