### PR TITLE
Implement the `open` function

### DIFF
--- a/src/inapp.js
+++ b/src/inapp.js
@@ -184,6 +184,18 @@ const BOT = [
   /Googlebot|facebookexternalhit|AdsBot-Google|Google Keyword Suggestion|Facebot|YandexBot|YandexMobileBot|bingbot|ia_archiver|AhrefsBot|Ezooms|GSLFbot|WBSearchBot|Twitterbot|TweetmemeBot|Twikle|PaperLiBot|Wotbox|UnwindFetchor|Exabot|MJ12bot|YandexImages|TurnitinBot|Pingdom/,
 ];
 
+const tryOpenInIframe = (iframe, scheme, startTime, resolve) => {
+  iframe.src = scheme; // eslint-disable-line no-param-reassign
+  document.body.appendChild(iframe);
+
+  setTimeout(() => {
+    if (new Date().getTime() - startTime < 550) {
+      iframe.parentNode.removeChild(iframe);
+      resolve(false);
+    }
+  }, 500);
+};
+
 class InApp {
 
   ua = '';
@@ -237,12 +249,18 @@ class InApp {
     if (document) {
       return new Promise((resolve) => {
         const iframe = document.createElement('iframe');
+        const start = new Date().getTime();
         let app;
         let timeout;
 
+        iframe.style.border = 'none';
+        iframe.style.width = '1px';
+        iframe.style.height = '1px';
+
         switch (this.os) {
-          case 'ios':
+          case 'ios': {
             app = get(apps, 'ios', {});
+
             if (app.store) {
               timeout = setTimeout(() => {
                 window.location.href = app.store;
@@ -250,18 +268,44 @@ class InApp {
               }, 1500);
             }
 
-            iframe.onload = () => {
-              clearTimeout(timeout);
-              iframe.parentNode.removeChild(iframe);
-              resolve(true);
-              window.location.href = app.uri;
-            };
+            if (this.browser === 'safari') {
+              timeout = setTimeout(() => {
+                clearTimeout(timeout);
+                window.location.href = app.scheme;
+              }, 1500);
+            } else {
+              tryOpenInIframe(iframe, app.scheme, start, resolve);
+            }
 
-            iframe.src = app.uri;
-            iframe.setAttribute('style', 'display:none;');
-            document.body.appendChild(iframe);
             break;
-          case 'android':
+          }
+          case 'android': {
+            app = get(apps, 'android', {});
+
+            if (this.browser === 'chrome') {
+              if (app.packageName) {
+                window.location.href = `intent://#Intent;package=${app.packageName};scheme=${app.scheme};end`;
+                resolve(true);
+              } else {
+                let redirected = false;
+
+                window.location.href = app.scheme;
+                timeout = setTimeout(() => {
+                  if (!document.webkitHidden && !redirected &&
+                    new Date().getTime() - start < 550) {
+                    redirected = true;
+                    resolve(false);
+                  }
+                }, 500);
+              }
+            } else if (this.browser === 'firefox') {
+              tryOpenInIframe(iframe, app.scheme, start, resolve);
+            } else {
+              tryOpenInIframe(iframe, app.scheme, start, resolve);
+            }
+
+            break;
+          }
           default:
             resolve(false);
         }

--- a/src/inapp.js
+++ b/src/inapp.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-useless-escape */
 const findKey = require('lodash/findKey');
 const get = require('lodash/get');
 
@@ -32,7 +33,7 @@ const PHONE = {
   nintendo: /Nintendo 3DS/,
   amoi: /Amoi/,
   inq: /INQ/,
-  generic: /Tapatalk|PDA;|SAGEM|\bmmp\b|pocket|\bpsp\b|symbian|Smartphone|smartfon|treo|up.browser|up.link|vodafone|\bwap\b|nokia|Series40|Series60|S60|SonyEricsson|N900|MAUI.*WAP.*Browser/
+  generic: /Tapatalk|PDA;|SAGEM|\bmmp\b|pocket|\bpsp\b|symbian|Smartphone|smartfon|treo|up.browser|up.link|vodafone|\bwap\b|nokia|Series40|Series60|S60|SonyEricsson|N900|MAUI.*WAP.*Browser/,
 };
 
 const TABLET = {

--- a/src/inapp.js
+++ b/src/inapp.js
@@ -299,8 +299,6 @@ class InApp {
                   }
                 }, 500);
               }
-            } else if (this.browser === 'firefox') {
-              tryOpenInIframe(iframe, app.scheme, start, resolve);
             } else {
               tryOpenInIframe(iframe, app.scheme, start, resolve);
             }

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,8 @@ class App extends Component {
     value: '',
     useragent: '',
     isShowButton: true,
-    uri: 'twitter://',
+    scheme: 'twitter://timeline',
+    packageName: 'com.twitter.android',
   }
 
   componentWillMount() {
@@ -37,11 +38,12 @@ class App extends Component {
     new Clipboard('.copy'); // eslint-disable-line
   }
 
-  onUriChange = e => this.setState({ uri: e.target.value });
+  onSchemeChange = e => this.setState({ scheme: e.target.value });
+  onPackageNameChange = e => this.setState({ packageName: e.target.value });
 
   onOpenClick = async () => {
-    const { inapp, uri } = this.state;
-    const reply = await inapp.open({ ios: { uri } });
+    const { inapp, scheme, packageName } = this.state;
+    const reply = await inapp.open({ [inapp.os]: { scheme, packageName } });
     if (!reply) alert('Cannot Open'); // eslint-disable-line
   }
 
@@ -52,7 +54,7 @@ class App extends Component {
   }
 
   render() {
-    const { inapp, value, uri, isShowButton } = this.state;
+    const { inapp, value, scheme, packageName, isShowButton } = this.state;
 
     return (
       <div>
@@ -106,12 +108,15 @@ class App extends Component {
           </div>
           <div className="p-3 border position-relative">
             <div className="input-group">
-              <input className="form-control" type="text" defaultValue={uri} onChange={this.onUriChange} />
+              <input className="form-control" type="text" defaultValue={scheme} onChange={this.onSchemeChange} placeholder="Scheme" />
               <span className="input-group-button">
                 <button className="btn" onClick={this.onOpenClick}>
                   <DiffRenamed />
                 </button>
               </span>
+              <div>
+                <input className="form-control" type="text" defaultValue={packageName} onChange={this.onPackageNameChange} placeholder="Android package name" />
+              </div>
             </div>
             <div className="border position-absolute right-0 top-0 p-1">inapp.open()</div>
           </div>

--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ class App extends Component {
           <div className="p-3 border position-relative">
             <div>{inapp.browser}</div>
             {isShowButton && ['Messenger', 'Facebook', 'LINE', 'WeChat', 'Twitter', 'Instagram', 'Snapchat', 'Chrome', 'Firefox', 'Safari', 'Internet', 'Explorer', 'Android Native', 'Vivaldi', 'MI', 'Puffin', 'Other', 'QRCode Scanner'].map(name => (
-              <button className="btn" onClick={() => this.onBrowserClick(name)}>{name}</button>
+              <button key={name} className="btn" onClick={() => this.onBrowserClick(name)}>{name}</button>
             ))}
             <div className="border position-absolute right-0 top-0 p-1">inapp.browser</div>
           </div>


### PR DESCRIPTION
Try and test on different devices again and again made me feel a little dizzy... anyway, it should be refactor in better way. 😅 

* Implement the `open` function:
	- Removed the `display: none` style of iframe, because seems that causes the iframe not working.
	- Android's case is much more complicated, I am not sure if it can work on all the Android Browsers.
		- When user set the `packageName`:
			- Chrome:
				- Not installed app: Cannot open the app (by `scheme`) on Chrome Android definitely, so it will open the app's download page on Google Play.
				- Installed: Just open the app by `scheme`.
			- Other browsers:
				- Try the iframe approach. It will resolve with false if it cannot be opened.
		- Without `packageName`:
			- Chrome:
				- Try to open it, and also resolve with false if cannot be opened (detect in Chrome way).
			- Other browsers:
				- Try the iframe approach. It will resolve with false if it cannot be opened.
	- Other devices:
		- Not implement in this pull request.

* reference:
	- https://stackoverflow.com/questions/7231085/how-to-fall-back-to-marketplace-when-android-custom-url-scheme-not-handled
	- http://qiita.com/kzhrk/items/842c046265e4e50914c6#androidchrome
	- https://blog.patw.me/archives/1069/js-app-url-scheme-open-workaround/
