### PR TITLE
feat: split lodash.findkey instead of lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lib"
   ],
   "dependencies": {
-    "lodash": "^4.17.5"
+    "lodash.findkey": "^4.6.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
@@ -38,6 +38,7 @@
     "eslint-plugin-react": "^7.0.1",
     "gh-pages": "^1.0.0",
     "jest": "^20.0.3",
+    "lodash": "^4.17.5",
     "primer-css": "^6.0.0",
     "react": "15.5.4",
     "react-dom": "15.5.4",

--- a/src/inapp.js
+++ b/src/inapp.js
@@ -1,4 +1,4 @@
-const findKey = require('lodash/findKey');
+const findKey = require('lodash.findkey');
 
 const BROWSER = {
   messenger: /\bFB[\w_]+\/(Messenger|MESSENGER)/,


### PR DESCRIPTION
reduce size
Before | After
------------ | -------------
![Screen Shot 2020-11-04 at 5 01 13 PM](https://user-images.githubusercontent.com/47012/98091061-d40ada80-1ebf-11eb-9fce-43b99415df5c.png) | ![Screen Shot 2020-11-04 at 5 01 30 PM](https://user-images.githubusercontent.com/47012/98091072-d79e6180-1ebf-11eb-8e22-d814be35a1bc.png)
85.37k | 62.81k

